### PR TITLE
build fprime led blinker unit tests

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -208,6 +208,7 @@
   vars:
     fprime_version: "v3.3.0"
     arduino_cli_cmake_wrapper_version: "94c3145e5ea4a0a48dc3f70560dfb8a"
+    fprime_led_blinker_version: "5a0031db1d87a87e6ec343827cc5956d54b76509"
 
   tasks:
   - name: Update OS to point python to python3
@@ -231,6 +232,38 @@
   - name: Install fprime python packages & dependencies
     pip:
       requirements: https://raw.githubusercontent.com/nasa/fprime/{{ fprime_version }}/requirements.txt
+  - name: Clone fprime led blinker repo
+    shell:
+      cmd: git clone --recursive https://github.com/fprime-community/fprime-workshop-led-blinker.git
+      chdir: /home/kasm-default-profile/
+      executable: /bin/bash
+  - name: Checkout {{ fprime_led_blinker_version }} in fprime led blinker repo
+    shell:
+      cmd: git checkout {{ fprime_led_blinker_version }}
+      chdir: /home/kasm-default-profile/fprime-workshop-led-blinker
+      executable: /bin/bash
+  - name: Fetch fprime submodule
+    shell:
+      cmd: git fetch
+      chdir: /home/kasm-default-profile/fprime-workshop-led-blinker/fprime
+      executable: /bin/bash
+  - name: Checkout {{ fprime_version }} in fprime submodule
+    shell:
+      cmd: git checkout {{ fprime_version }}
+      chdir: /home/kasm-default-profile/fprime-workshop-led-blinker/fprime
+      executable: /bin/bash
+  - name: Generate fprime led blinker unit tests
+    shell:
+      cmd: fprime-util generate --ut
+      chdir: /home/kasm-default-profile/fprime-workshop-led-blinker
+      executable: /bin/bash
+  - name: Build fprime led blinker unit tests
+    shell:
+      cmd: fprime-util check 1> /tmp/fprime_workshop_led_blinker_build_output.txt
+      chdir: /home/kasm-default-profile/fprime-workshop-led-blinker
+      executable: /bin/bash
+  - name: Delete fprime led blinker repo
+    shell: rm -rf /home/kasm-default-profile/fprime-workshop-led-blinker
 
 -
   # install arduino-cli


### PR DESCRIPTION
closes #10 

- recursively clone fprime-workshop-led-blinker
- fetch & checkout v3.3.0 in fprime submodule
- build unit tests